### PR TITLE
Add bat script to remove the requirement for admin rights.

### DIFF
--- a/isaacsim_links/core.py
+++ b/isaacsim_links/core.py
@@ -4,6 +4,7 @@ Isaac Sim Link Manager core functionality
 
 import os
 import sys
+import subprocess
 import platform
 import json
 from pathlib import Path
@@ -161,7 +162,13 @@ def create_symlink_safely(
     except OSError as e:
         logger.error(f"Error: Failed to create link: {e}")
         if platform.system() == "Windows":
-            logger.error("Windows tip: Please ensure running as administrator or enable developer mode.")
+            try:
+                bat_file = Path(__file__).parent / "setup_symlink.bat"
+                cmd = [str(bat_file), link_path, source ]
+                logger.info(f"Windows tip: Not running as administrator - trying alternative {bat_file} script.")
+                subprocess.run(cmd)
+            except:
+                logger.error("Windows tip: Please ensure running as administrator or enable developer mode.")
         return False
     except Exception as e:
         logger.error(f"Unexpected error occurred: {e}")
@@ -240,6 +247,9 @@ def create_links(use_new_mode=True):
 
                 ext_name = item.name
                 logger.info(f"Processing extension directory: {ext_name}")
+
+                if "core" in ext_name:
+                    print(ext_name)
 
                 if use_new_mode:
                     # --- New mode logic ---
@@ -706,5 +716,5 @@ if __name__ == "__main__":
         "Script imported as module, not executing link operations. Please call create_links() or remove_links() from other scripts."
     )
     # If you really want to execute some operations when running directly, uncomment the line below:
-    # logger.info("Running script directly, executing create links operation (old mode)...")
-    # create_links()
+    logger.info("Running script directly, executing create links operation (old mode)...")
+    create_links()

--- a/isaacsim_links/setup_symlink.bat
+++ b/isaacsim_links/setup_symlink.bat
@@ -1,0 +1,29 @@
+@echo off
+setlocal
+
+:: Validate arguments
+if "%~2"=="" (
+    echo Usage: %~nx0 [LinkPath] [TargetPath]
+    echo Example: %~nx0 "C:\Users\YourName\IsaacLab\_isaac_sim" "C:\Users\YourName\isaacsim"
+    exit /b 1
+)
+
+set "LINK_PATH=%~1"
+set "TARGET_PATH=%~2"
+
+:: Check if symlink already exists
+if exist "%LINK_PATH%\" (
+    echo Symlink or directory already exists at %LINK_PATH%.
+) else (
+    :: Create the junction
+    powershell -Command "New-Item -ItemType Junction -Path '%LINK_PATH%' -Target '%TARGET_PATH%'"
+
+    if %ERRORLEVEL% neq 0 (
+        echo Failed to create symlink at %LINK_PATH%.
+        exit /b 1
+    ) else (
+        echo Symlink created at %LINK_PATH% pointing to %TARGET_PATH%.
+    )
+)
+
+exit /b 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ isaacsim-links = "isaacsim_links.cli:main"
 [tool.setuptools]
 packages = ["isaacsim_links"]
 
+[tool.setuptools.package-data]
+"isaacsim_links" = ["./setup_symlink.bat"]
+


### PR DESCRIPTION
I don't know if bat scripts are allowed in python modules but this simple setup_symlink bat script removes the need for admin access.   You might be able to call the PowerShell command directly from os but I already had this bat script laying around. 